### PR TITLE
[feat] apply infinite retry for loading init state of network service

### DIFF
--- a/ChatCore/Protocols/ChatNetworkServicing.swift
+++ b/ChatCore/Protocols/ChatNetworkServicing.swift
@@ -24,12 +24,15 @@ public protocol ChatNetworkServicing {
 
     /// Current user logged in to the app
     var currentUser: U? { get }
-    
-    /// Allow init network service and observe loading state at different places
-    var didFinishedLoading: ((Result<Void, ChatError>) -> Void)? { get set }
 
     init(config: Config)
-    
+
+    /// Initial loading of network service.
+    ///
+    /// - Parameters:
+    ///   - completion: Called when network service is loaded or error appeared.
+    func load(completion: @escaping (Result<Void, ChatError>) -> Void)
+
     /// Send a message to the specified conversation.
     ///
     /// - Parameters:

--- a/ChatNetworkingFirestore/ChatNetworkingFirestore.swift
+++ b/ChatNetworkingFirestore/ChatNetworkingFirestore.swift
@@ -25,7 +25,6 @@ public class ChatNetworkingFirestore: ChatNetworkServicing {
     let database: Firestore
 
     public private(set) var currentUser: UserFirestore?
-    public var didFinishedLoading: ((Result<Void, ChatError>) -> Void)?
     
     private var listeners: [Listener: ListenerRegistration] = [:]
     private var currentUserId: String?
@@ -52,10 +51,6 @@ public class ChatNetworkingFirestore: ChatNetworkServicing {
         
         // FIXME: Remove this temporary code when UI for conversation creating is ready
         NotificationCenter.default.addObserver(self, selector: #selector(createTestConversation), name: NSNotification.Name(rawValue: "TestConversation"), object: nil)
-        
-        load { [weak self] result in
-            self?.didFinishedLoading?(result)
-        }
     }
     
     deinit {


### PR DESCRIPTION
I enhanced logic for task management to have option to infinite retry. It works for loading. 
I see big potential problem we will have soon and that is to observe loading state (other states at UI).
Check this out. Thx