### PR TITLE
[hotfix] cached message to set own id correctly

### DIFF
--- a/ChatCore/Models/CachedMessage.swift
+++ b/ChatCore/Models/CachedMessage.swift
@@ -13,11 +13,11 @@ struct CachedMessage<T: MessageSpecifying & Cachable>: Codable {
 
     let content: T
     let conversationId: ObjectIdentifier
-    private let id: ObjectIdentifier
+    let id: ObjectIdentifier
     private(set) var state: CachedMessageState
 
     init(content: T, conversationId: ObjectIdentifier, state: CachedMessageState) {
-        id = UUID().uuidString
+        self.id = UUID().uuidString
         self.content = content
         self.conversationId = conversationId
         self.state = state


### PR DESCRIPTION
@schwarja During developing message state I found out critical bug, which was not obvious. But little change on cache message id generation made that cached messages were not removed (always new id) and rapidly grew in cache. Resend those unsent message than made hell in DB