### PR TITLE
[feat] add user to cached message to validate it before resending

### DIFF
--- a/ChatCore/Models/CachedMessage.swift
+++ b/ChatCore/Models/CachedMessage.swift
@@ -14,13 +14,15 @@ struct CachedMessage<T: MessageSpecifying & Cachable>: Codable {
     let content: T
     let conversationId: ObjectIdentifier
     let id: ObjectIdentifier
+    let userId: ObjectIdentifier
     private(set) var state: CachedMessageState
 
-    init(content: T, conversationId: ObjectIdentifier, state: CachedMessageState) {
+    init(content: T, conversationId: ObjectIdentifier, userId: ObjectIdentifier, state: CachedMessageState) {
         self.id = UUID().uuidString
         self.content = content
         self.conversationId = conversationId
         self.state = state
+        self.userId = userId
     }
 
     // change state of cached message


### PR DESCRIPTION
Cache message has from now userId who tried to send it. Later when reloading messages from cache are all from other users thrown away.
I left there two todos to unify user checking approach from firebase auth branch when merging