### PR TITLE
[fix] avoid setting same last seen message multiple times

### DIFF
--- a/ChatCore/Classes/ChatCore.swift
+++ b/ChatCore/Classes/ChatCore.swift
@@ -200,6 +200,11 @@ extension ChatCore {
             return
         }
 
+        // avoid updating same last seen message
+        guard existingConversation.lastMessage.id != message.id else {
+            return
+        }
+
         taskManager.run(attributes: [.backgroundTask, .backgroundThread, .afterInit]) { [weak self] _ in
             let seenMessage = Networking.M(uiModel: message)
             let conversation = Networking.C(uiModel: existingConversation)


### PR DESCRIPTION
I added new condition at chat core to avoid multiple updating last seen message for same message