### PR TITLE
Feature/add transactions

### DIFF
--- a/ChatCore/Classes/ChatCore.swift
+++ b/ChatCore/Classes/ChatCore.swift
@@ -220,7 +220,7 @@ extension ChatCore {
         taskManager.run(attributes: [.backgroundTask, .backgroundThread, .afterInit]) { [weak self] _ in
             let seenMessage = Networking.M(uiModel: message)
             let conversation = Networking.C(uiModel: existingConversation)
-            self?.networking.updateSeenMessage(seenMessage, in: conversation)
+            self?.networking.updateSeenMessage(seenMessage, in: conversation.id)
         }
     }
 }

--- a/ChatCore/Protocols/ChatNetworkServicing.swift
+++ b/ChatCore/Protocols/ChatNetworkServicing.swift
@@ -56,8 +56,8 @@ public protocol ChatNetworkServicing {
     ///
     /// - Parameters:
     ///   - message: Message to be set as last seen
-    ///   - conversation: Target conversation
-    func updateSeenMessage(_ message: M, in conversation: C)
+    ///   - conversation: Target conversation id
+    func updateSeenMessage(_ message: M, in conversation: EntityIdentifier)
 
     /// Creates a listener to conversations. First set of data is received immediately by the completion callback. The same callback is called when requesting more data.
     ///

--- a/ChatNetworkingFirestore/ChatNetworkingFirestore.swift
+++ b/ChatNetworkingFirestore/ChatNetworkingFirestore.swift
@@ -63,14 +63,11 @@ public extension ChatNetworkingFirestore {
 
 // MARK: Update conversation
 public extension ChatNetworkingFirestore {
-    func updateSeenMessage(_ message: MessageFirestore, in conversation: ConversationFirestore) {
-
-        var conversation = conversation
-        conversation.setSeenMessages((messageId: message.id, seenAt: Date()), currentUserId: currentUserId)
+    func updateSeenMessage(_ message: MessageFirestore, in conversation: EntityIdentifier) {
 
         let reference = database
-        .collection(Constants.conversationsPath)
-        .document(conversation.id)
+            .collection(Constants.conversationsPath)
+            .document(conversation)
 
         database.runTransaction({ (transaction, errorPointer) -> Any? in
             var currentConversation: ConversationFirestore?
@@ -100,9 +97,9 @@ public extension ChatNetworkingFirestore {
             return nil
         }, completion: { (_, error) in
             if let err = error {
-                print("Error updating document: \(err)")
+                print("Error updating conversation last seen message: \(err)")
             } else {
-                print("Document successfully updated")
+                print("Conversation last seen message successfully updated")
             }
         })
     }
@@ -433,7 +430,7 @@ extension ChatNetworkingFirestore: ChatNetworkingWithTypingUsers {
     private func setTypingUser(typingUserReference: DocumentReference) {
         typingUserReference.setData([:]) { error in
             if let err = error {
-                print("Error updating document: \(err)")
+                print("Error updating user typing: \(err)")
             } else {
                 print("Typing user successfully set")
             }
@@ -443,7 +440,7 @@ extension ChatNetworkingFirestore: ChatNetworkingWithTypingUsers {
     private func removeTypingUser(typingUserReference: DocumentReference) {
         typingUserReference.delete { error in
             if let err = error {
-                print("Error deleting document: \(err)")
+                print("Error deleting user typing: \(err)")
             } else {
                 print("Typing user successfully removed")
             }


### PR DESCRIPTION
Resume:
After all I realize that we can use transaction only at one useful place - send message. Bc of many limitations (can read data after first CUD operation, cant get last document by query etc) its counter-productive to use for delete method.
Also bc of limitation its impossible to load message after its sent in transaction and return in callback. As we discussed I used approach to return just id immediately and data are fully reloaded in listen to callback. 