### PR TITLE
Send just message id when updating seen message info

### DIFF
--- a/ChatCore/Classes/ChatCore.swift
+++ b/ChatCore/Classes/ChatCore.swift
@@ -257,7 +257,7 @@ extension ChatCore {
 
 // MARK: - Seen flag
 extension ChatCore {
-    open func updateSeenMessage(_ message: MessageUI, in conversation: EntityIdentifier) {
+    open func updateSeenMessage(_ message: EntityIdentifier, in conversation: EntityIdentifier) {
 
         taskManager.run(attributes: [.backgroundTask, .backgroundThread(coreQueue), .afterInit]) { [weak self] _ in
             guard let self = self else {
@@ -271,13 +271,11 @@ extension ChatCore {
             }
 
             // avoid updating same seen message
-            guard existingConversation.seen[self.currentUser.id]?.messageId != message.id else {
+            guard existingConversation.seen[self.currentUser.id]?.messageId != message else {
                 return
             }
 
-            let seenMessage = Networking.NetworkMessage(uiModel: message)
-            let conversation = Networking.NetworkConversation(uiModel: existingConversation)
-            self.networking.updateSeenMessage(seenMessage, in: conversation.id)
+            self.networking.updateSeenMessage(message, in: conversation)
         }
     }
 }

--- a/ChatCore/Protocols/Services/ChatCoreServicing.swift
+++ b/ChatCore/Protocols/Services/ChatCoreServicing.swift
@@ -105,9 +105,9 @@ public protocol ChatCoreServicing {
     /// Send a request to set `message` as the last seen message by current user
     ///
     /// - Parameters:
-    ///   - message: Message to be set as last seen
-    ///   - conversation: Target conversation
-    func updateSeenMessage(_ message: CoreMessage, in conversation: EntityIdentifier)
+    ///   - message: Identifier of a message to be set as last seen
+    ///   - conversation: Identifier of a target conversation
+    func updateSeenMessage(_ message: EntityIdentifier, in conversation: EntityIdentifier)
 }
 
 // MARK: Default page size

--- a/ChatCore/Protocols/Services/ChatNetworkServicing.swift
+++ b/ChatCore/Protocols/Services/ChatNetworkServicing.swift
@@ -53,9 +53,9 @@ public protocol ChatNetworkServicing {
     /// Send a request to set `message` as the last seen message by current user
     ///
     /// - Parameters:
-    ///   - message: Message to be set as last seen
-    ///   - conversation: Target conversation id
-    func updateSeenMessage(_ message: NetworkMessage, in conversation: EntityIdentifier)
+    ///   - message: Identifier of a message to be set as last seen
+    ///   - conversation: Identifier of a target conversation
+    func updateSeenMessage(_ message: EntityIdentifier, in conversation: EntityIdentifier)
 
     /// Creates a listener to single conversation.
     ///

--- a/ChatNetworkingFirestore/Implementations/Firestore/ChatFirestore.swift
+++ b/ChatNetworkingFirestore/Implementations/Firestore/ChatFirestore.swift
@@ -91,7 +91,7 @@ public extension ChatFirestore {
 
 // MARK: Update conversation
 public extension ChatFirestore {
-    func updateSeenMessage(_ message: MessageFirestore, in conversation: EntityIdentifier) {
+    func updateSeenMessage(_ message: EntityIdentifier, in conversation: EntityIdentifier) {
 
         networkingQueue.async { [weak self] in
             guard let self = self else {
@@ -122,7 +122,7 @@ public extension ChatFirestore {
                 })
                 
                 json[self.currentUserId] = [
-                    self.constants.conversations.seenAttribute.messageIdAttributeName: message.id,
+                    self.constants.conversations.seenAttribute.messageIdAttributeName: message,
                     self.constants.conversations.seenAttribute.timestampAttributeName: Timestamp()
                 ]
 

--- a/ChatUI/Scenes/MessagesList/ViewModel/MessagesListViewModel.swift
+++ b/ChatUI/Scenes/MessagesList/ViewModel/MessagesListViewModel.swift
@@ -82,7 +82,7 @@ class MessagesListViewModel<Core: ChatUICoreServicing>: MessagesListViewModeling
     }
     
     func updateSeenMessage(_ message: Message) {
-        core.updateSeenMessage(message, in: conversation.id)
+        core.updateSeenMessage(message.id, in: conversation.id)
     }
     
     func send(message: MessageSpecification, completion: @escaping (Result<Message, ChatError>) -> Void) {


### PR DESCRIPTION
I realized there is no need to send whole message object when we want to update seen message info