### PR TITLE
Move typing users to conversation

### DIFF
--- a/ChatApp/ChatApp.xcodeproj/project.pbxproj
+++ b/ChatApp/ChatApp.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		04BF183D242E09A100C1D626 /* EmptyConversationsList.xib in Resources */ = {isa = PBXBuildFile; fileRef = 04BF183C242E09A100C1D626 /* EmptyConversationsList.xib */; };
 		04BF183F242E0AFA00C1D626 /* EmptyConversationsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BF183E242E0AFA00C1D626 /* EmptyConversationsList.swift */; };
 		04C0ECE724201F08008A5ADB /* UIConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C0ECE624201F08008A5ADB /* UIConfig.swift */; };
+		04E1FCB9255438BD00D88120 /* TypingStatusRepresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E1FCB8255438BD00D88120 /* TypingStatusRepresenting.swift */; };
 		04E56CFD241EBEB6001F54A9 /* ConversationsListCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E56CFB241EBE91001F54A9 /* ConversationsListCellViewModel.swift */; };
 		04E56D00242003F9001F54A9 /* UIView+Fill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E56CFE242003E7001F54A9 /* UIView+Fill.swift */; };
 		04E56D0324200484001F54A9 /* Array+Subscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E56D012420045B001F54A9 /* Array+Subscript.swift */; };
@@ -303,6 +304,7 @@
 		04C0ECD624201B82008A5ADB /* Catamaran-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Catamaran-Regular.ttf"; sourceTree = "<group>"; };
 		04C0ECD724201B82008A5ADB /* Catamaran-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Catamaran-Bold.ttf"; sourceTree = "<group>"; };
 		04C0ECE624201F08008A5ADB /* UIConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIConfig.swift; sourceTree = "<group>"; };
+		04E1FCB8255438BD00D88120 /* TypingStatusRepresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingStatusRepresenting.swift; sourceTree = "<group>"; };
 		04E56CFB241EBE91001F54A9 /* ConversationsListCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationsListCellViewModel.swift; sourceTree = "<group>"; };
 		04E56CFE242003E7001F54A9 /* UIView+Fill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Fill.swift"; sourceTree = "<group>"; };
 		04E56D012420045B001F54A9 /* Array+Subscript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Subscript.swift"; sourceTree = "<group>"; };
@@ -1069,6 +1071,7 @@
 				C11E9E2C23EDCD1E005E10A1 /* MessageRepresenting.swift */,
 				C11E9E3323EDCD1E005E10A1 /* ConversationRepresenting.swift */,
 				C11E9DFF23EDCCDA005E10A1 /* SeenMessageRepresenting.swift */,
+				04E1FCB8255438BD00D88120 /* TypingStatusRepresenting.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1663,6 +1666,7 @@
 				843D814F2406D81300C62656 /* IdentifiableClosure.swift in Sources */,
 				84BE30D0242B46B900DA8664 /* MessageStateReflecting.swift in Sources */,
 				049862C723FEEBAF00F7EFD6 /* DataManager.swift in Sources */,
+				04E1FCB9255438BD00D88120 /* TypingStatusRepresenting.swift in Sources */,
 				843A584524168B1A007E6F45 /* KeychainSwift.swift in Sources */,
 				843D81542406E90F00C62656 /* TaskManager.swift in Sources */,
 				8478F5C024239725002BC890 /* CachedMessageState.swift in Sources */,

--- a/ChatApp/ChatApp/Models/Conversation.swift
+++ b/ChatApp/ChatApp/Models/Conversation.swift
@@ -9,12 +9,13 @@
 import Foundation
 import ChatCore
 
-struct Conversation: ConversationRepresenting {
+struct Conversation: ConversationRepresenting, TypingStatusRepresenting {
     let id: EntityIdentifier
     let lastMessage: Message?
     let memberIds: [EntityIdentifier]
     var members: [User] = []
     let seen: [String: SeenItem]
+    var typingUsers: [EntityIdentifier: Bool]
 }
 
 extension Conversation: ChatModel {}
@@ -25,5 +26,6 @@ extension Conversation: Decodable {
         case lastMessage
         case memberIds = "members"
         case seen
+        case typingUsers
     }
 }

--- a/ChatCore/Classes/ChatCore.swift
+++ b/ChatCore/Classes/ChatCore.swift
@@ -504,7 +504,7 @@ extension ChatCore: ChatCoreServicingWithTypingUsers where
     // Typing users feature requirements
     Networking: ChatNetworkingWithTypingUsers {
 
-    open func setCurrentUserTyping(isTyping: Bool, in conversation: EntityIdentifier) {
+    open func setCurrentUserTyping(isTyping: Bool, in conversation: TypingStatusRepresenting) {
         taskManager.run(attributes: [.backgroundTask, .backgroundThread(coreQueue), .afterInit]) { [weak self] _ in
             guard let self = self else {
                 return
@@ -513,28 +513,6 @@ extension ChatCore: ChatCoreServicingWithTypingUsers where
             precondition(self.$currentUser, "Current user is nil when calling \(#function)")
             self.networking.setUserTyping(userId: self.currentUser.id, isTyping: isTyping, in: conversation)
         }
-    }
-
-    open func listenToTypingUsers(in conversation: EntityIdentifier, completion: @escaping (Result<[EntityIdentifier], ChatError>) -> Void) -> Listener {
-
-        let listener = Listener.typingUsers(conversationId: conversation)
-        taskManager.run(attributes: [.backgroundTask, .backgroundThread(coreQueue), .afterInit]) { [weak self] taskCompletion in
-            guard let self = self else {
-                return
-            }
-            precondition(self.$currentUser, "Current user is nil when calling \(#function)")
-
-            self.networking.listenToTypingUsers(in: conversation) { result in
-                self.coreQueue.async {
-                    self.taskHandler(result: result, completion: taskCompletion)
-                    DispatchQueue.main.async {
-                        completion(result)
-                    }
-                }
-            }
-        }
-
-        return listener
     }
 }
 

--- a/ChatCore/Classes/ChatCore.swift
+++ b/ChatCore/Classes/ChatCore.swift
@@ -504,7 +504,7 @@ extension ChatCore: ChatCoreServicingWithTypingUsers where
     // Typing users feature requirements
     Networking: ChatNetworkingWithTypingUsers {
 
-    open func setCurrentUserTyping(isTyping: Bool, in conversation: TypingStatusRepresenting) {
+    open func setCurrentUserTyping(isTyping: Bool, in conversation: EntityIdentifier) {
         taskManager.run(attributes: [.backgroundTask, .backgroundThread(coreQueue), .afterInit]) { [weak self] _ in
             guard let self = self else {
                 return

--- a/ChatCore/Protocols/Models/TypingStatusRepresenting.swift
+++ b/ChatCore/Protocols/Models/TypingStatusRepresenting.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-public protocol TypingStatusRepresenting where Self: EntityIdentifiable {
+public protocol TypingStatusRepresenting {
     var typingUsers: [EntityIdentifier: Bool] { get set }
 }

--- a/ChatCore/Protocols/Models/TypingStatusRepresenting.swift
+++ b/ChatCore/Protocols/Models/TypingStatusRepresenting.swift
@@ -1,0 +1,13 @@
+//
+//  TypingStatusRepresenting.swift
+//  ChatCore
+//
+//  Created by Daniel Pecher on 05/11/2020.
+//  Copyright © 2020 Jan Schwarz. All rights reserved.
+//
+
+import Foundation
+
+public protocol TypingStatusRepresenting where Self: EntityIdentifiable {
+    var typingUsers: [EntityIdentifier: Bool] { get set }
+}

--- a/ChatCore/Protocols/Services/ChatCoreServicingWithTypingUsers.swift
+++ b/ChatCore/Protocols/Services/ChatCoreServicingWithTypingUsers.swift
@@ -15,14 +15,5 @@ public protocol ChatCoreServicingWithTypingUsers {
     /// - Parameters:
     ///   - isTyping: flag if current user is / isn't typing
     ///   - conversation: Conversation id
-    func setCurrentUserTyping(isTyping: Bool, in conversation: EntityIdentifier)
-
-    /// Creates a listener to typing users. First set of data is received immediately by the completion callback.
-    ///
-    /// Returns a ListenerIdentifier instance which is later used to cancel the created listener.
-    ///
-    /// - Parameters:
-    ///   - conversation: Conversation ID
-    ///   - completion: Returns IDs of typing users. Called upon receiving data (or encountering an error)
-    func listenToTypingUsers(in conversation: EntityIdentifier, completion: @escaping (Result<[EntityIdentifier], ChatError>) -> Void) -> Listener
+    func setCurrentUserTyping(isTyping: Bool, in conversation: TypingStatusRepresenting)
 }

--- a/ChatCore/Protocols/Services/ChatCoreServicingWithTypingUsers.swift
+++ b/ChatCore/Protocols/Services/ChatCoreServicingWithTypingUsers.swift
@@ -15,5 +15,5 @@ public protocol ChatCoreServicingWithTypingUsers {
     /// - Parameters:
     ///   - isTyping: flag if current user is / isn't typing
     ///   - conversation: Conversation id
-    func setCurrentUserTyping(isTyping: Bool, in conversation: TypingStatusRepresenting)
+    func setCurrentUserTyping(isTyping: Bool, in conversation: EntityIdentifier)
 }

--- a/ChatCore/Protocols/Services/ChatNetworkingWithTypingUsers.swift
+++ b/ChatCore/Protocols/Services/ChatNetworkingWithTypingUsers.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-// swiftlint:disable type_name
 /// Defines networking with ability to listen and manage users who are typing
 public protocol ChatNetworkingWithTypingUsers {
     /// Manages user who is typing in conversation
@@ -17,12 +16,5 @@ public protocol ChatNetworkingWithTypingUsers {
     ///   - userId: User id
     ///   - conversation: Conversation id
     ///   - isTyping: flag if current user is / isn't typing
-    func setUserTyping(userId: EntityIdentifier, isTyping: Bool, in conversation: EntityIdentifier)
-
-    /// Creates a listener to typing users. First set of data is received immediately by the completion callback.
-    ///
-    /// - Parameters:
-    ///   - conversation: Conversation ID
-    ///   - completion: User IDs of typing users. Called upon receiving data (or encountering an error)
-    func listenToTypingUsers(in conversation: EntityIdentifier, completion: @escaping (Result<[EntityIdentifier], ChatError>) -> Void)
+    func setUserTyping(userId: EntityIdentifier, isTyping: Bool, in conversation: TypingStatusRepresenting)
 }

--- a/ChatCore/Protocols/Services/ChatNetworkingWithTypingUsers.swift
+++ b/ChatCore/Protocols/Services/ChatNetworkingWithTypingUsers.swift
@@ -16,5 +16,5 @@ public protocol ChatNetworkingWithTypingUsers {
     ///   - userId: User id
     ///   - conversation: Conversation id
     ///   - isTyping: flag if current user is / isn't typing
-    func setUserTyping(userId: EntityIdentifier, isTyping: Bool, in conversation: TypingStatusRepresenting)
+    func setUserTyping(userId: EntityIdentifier, isTyping: Bool, in conversation: EntityIdentifier)
 }

--- a/ChatNetworkingFirestore/Implementations/Firestore/ChatFirestore+Typing.swift
+++ b/ChatNetworkingFirestore/Implementations/Firestore/ChatFirestore+Typing.swift
@@ -10,56 +10,22 @@ import ChatCore
 import FirebaseFirestore
 
 extension ChatFirestore: ChatNetworkingWithTypingUsers {
-    public func setUserTyping(userId: EntityIdentifier, isTyping: Bool, in conversation: EntityIdentifier) {
+    public func setUserTyping(userId: EntityIdentifier, isTyping: Bool, in conversation: TypingStatusRepresenting) {
 
         networkingQueue.async { [weak self] in
             guard let self = self else {
                 return
             }
+            
             let document = self.database
                 .collection(self.constants.conversations.path)
-                .document(conversation)
-                .collection(self.constants.typingUsers.path)
-                .document(userId)
-
-            isTyping ? self.setTypingUser(typingUserReference: document) : self.removeTypingUser(typingUserReference: document)
-        }
-    }
-
-    private func setTypingUser(typingUserReference: DocumentReference) {
-        typingUserReference.setData([:]) { error in
-            if let err = error {
-                print("Error updating user typing: \(err)")
-            } else {
-                print("Typing user successfully set")
-            }
-        }
-    }
-
-    private func removeTypingUser(typingUserReference: DocumentReference) {
-        typingUserReference.delete { error in
-            if let err = error {
-                print("Error deleting user typing: \(err)")
-            } else {
-                print("Typing user successfully removed")
-            }
-        }
-    }
-
-    public func listenToTypingUsers(in conversation: EntityIdentifier, completion: @escaping (Result<[EntityIdentifier], ChatError>) -> Void) {
-
-        networkingQueue.async { [weak self] in
-            guard let self = self else {
-                return
-            }
-            let query = self.database
-                .collection(self.constants.conversations.path)
-                .document(conversation)
-                .collection(self.constants.typingUsers.path)
-
-            let listener = Listener.typingUsers(conversationId: conversation)
-
-            self.listenToCollection(query: query, listener: listener, completion: completion)
+                .document(conversation.id)
+            
+            document.setData([
+                self.constants.conversations.typingUsersAttributeName: [
+                    userId: isTyping
+                ]
+            ], merge: true)
         }
     }
 }

--- a/ChatNetworkingFirestore/Implementations/Firestore/ChatFirestore+Typing.swift
+++ b/ChatNetworkingFirestore/Implementations/Firestore/ChatFirestore+Typing.swift
@@ -10,7 +10,7 @@ import ChatCore
 import FirebaseFirestore
 
 extension ChatFirestore: ChatNetworkingWithTypingUsers {
-    public func setUserTyping(userId: EntityIdentifier, isTyping: Bool, in conversation: TypingStatusRepresenting) {
+    public func setUserTyping(userId: EntityIdentifier, isTyping: Bool, in conversation: EntityIdentifier) {
 
         networkingQueue.async { [weak self] in
             guard let self = self else {
@@ -19,9 +19,9 @@ extension ChatFirestore: ChatNetworkingWithTypingUsers {
             
             let document = self.database
                 .collection(self.constants.conversations.path)
-                .document(conversation.id)
+                .document(conversation)
             
-            self.database.runTransaction({ (transaction, error) -> Any? in
+            self.database.runTransaction({ (transaction, _) -> Any? in
                 guard
                     let conversation = try? transaction.getDocument(document),
                     let conversationData = conversation.data(),

--- a/ChatNetworkingFirestore/Implementations/Firestore/Constants/ChatFirestoreConstants.swift
+++ b/ChatNetworkingFirestore/Implementations/Firestore/Constants/ChatFirestoreConstants.swift
@@ -12,7 +12,6 @@ public struct ChatFirestoreConstants {
     public var conversations = Conversations()
     public var messages = Messages()
     public var users = Users()
-    public var typingUsers = TypingUsers()
     
     public init() {}
 }
@@ -32,6 +31,7 @@ public extension ChatFirestoreConstants {
         public var seenAttribute = SeenMessages()
         public var lastMessageAttributeName = "lastMessage"
         public var membersAttributeName = "members"
+        public var typingUsersAttributeName = "typingUsers"
     }
     
     struct SeenMessages {
@@ -43,9 +43,5 @@ public extension ChatFirestoreConstants {
     
     struct Users {
         public var path = "users"
-    }
-    
-    struct TypingUsers {
-        public var path = "typingUsers"
     }
 }


### PR DESCRIPTION
This PR changes the way typing is handled. 
* `Conversation` contains `typingUsers` dictionary that is updated using the `setCurrentUserTyping` method and the client app just needs to listen to `Conversation` updates and handle the `typingUsers` changes accordingly.