### PR TITLE
Allow to specify upload path when sending an image

### DIFF
--- a/ChatApp/ChatApp.xcodeproj/project.pbxproj
+++ b/ChatApp/ChatApp.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		045A6B3B24292CEF0055B5E1 /* UIView+Nib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045A6B3A24292CEF0055B5E1 /* UIView+Nib.swift */; };
 		045A6B3D242A10F60055B5E1 /* String+ChatStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045A6B3C242A10F60055B5E1 /* String+ChatStrings.swift */; };
 		045A6B40242A1B860055B5E1 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045A6B3F242A1B860055B5E1 /* AvatarView.swift */; };
+		045B65F5256E9AA800DB0C6C /* UploadPathSpecifying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045B65F4256E9AA800DB0C6C /* UploadPathSpecifying.swift */; };
 		048ED59424339BD500F9C7BA /* MessagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048ED59324339BD500F9C7BA /* MessagesViewController.swift */; };
 		0490E76A241E5F74008C4412 /* ConversationsListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0490E768241E5F74008C4412 /* ConversationsListCell.swift */; };
 		0490E76B241E5F74008C4412 /* ConversationsListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0490E769241E5F74008C4412 /* ConversationsListCell.xib */; };
@@ -285,6 +286,7 @@
 		045A6B3A24292CEF0055B5E1 /* UIView+Nib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Nib.swift"; sourceTree = "<group>"; };
 		045A6B3C242A10F60055B5E1 /* String+ChatStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+ChatStrings.swift"; sourceTree = "<group>"; };
 		045A6B3F242A1B860055B5E1 /* AvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
+		045B65F4256E9AA800DB0C6C /* UploadPathSpecifying.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UploadPathSpecifying.swift; sourceTree = "<group>"; };
 		048ED59324339BD500F9C7BA /* MessagesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesViewController.swift; sourceTree = "<group>"; };
 		0490E768241E5F74008C4412 /* ConversationsListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationsListCell.swift; sourceTree = "<group>"; };
 		0490E769241E5F74008C4412 /* ConversationsListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ConversationsListCell.xib; sourceTree = "<group>"; };
@@ -846,6 +848,7 @@
 				C1BD6335245867C60093769C /* MediaMessages */,
 				C11E9E2E23EDCD1E005E10A1 /* EntityIdentifiable.swift */,
 				C124E4B42452CE11006119CD /* JSONConvertible.swift */,
+				045B65F4256E9AA800DB0C6C /* UploadPathSpecifying.swift */,
 				84BE30CF242B46B900DA8664 /* MessageStateReflecting.swift */,
 				842C71C32426B94F0079145A /* MessageConvertible.swift */,
 				843A583B24114FE4007E6F45 /* Cachable.swift */,
@@ -1652,6 +1655,7 @@
 				C11E9E3723EDCD1E005E10A1 /* Error.swift in Sources */,
 				C1888D842459A78D00E0136A /* ChatModel.swift in Sources */,
 				842C71C42426B94F0079145A /* MessageConvertible.swift in Sources */,
+				045B65F5256E9AA800DB0C6C /* UploadPathSpecifying.swift in Sources */,
 				C11E9E3C23EDCD1E005E10A1 /* MessageSpecifying.swift in Sources */,
 				C11E9E3823EDCD1E005E10A1 /* EntityIdentifier.swift in Sources */,
 				842C71C62426C7230079145A /* MessageState.swift in Sources */,

--- a/ChatCore/Protocols/Services/MediaUploading.swift
+++ b/ChatCore/Protocols/Services/MediaUploading.swift
@@ -15,5 +15,5 @@ public protocol MediaUploading {
     ///   - content: Media content that conforms to `MediaContent` protocol
     ///   - queue: `DispatchQueue` on which the `completion` should be called
     ///   - completion: Closure that is called on completion or error
-    func upload(content: MediaContent, on queue: DispatchQueue, completion: @escaping (Result<URL, ChatError>) -> Void)
+    func upload(content: MediaContent, path: String?, on queue: DispatchQueue, completion: @escaping (Result<URL, ChatError>) -> Void)
 }

--- a/ChatCore/Protocols/UploadPathSpecifying.swift
+++ b/ChatCore/Protocols/UploadPathSpecifying.swift
@@ -1,0 +1,13 @@
+//
+//  UploadPathSpecifying.swift
+//  STRVChatCore
+//
+//  Created by Daniel Pecher on 25/11/2020.
+//
+
+import Foundation
+
+public protocol UploadPathSpecifying {
+    /// return nil to use default path
+    var uploadPath: String? { get }
+}

--- a/ChatNetworkingFirestore/Implementations/Firestore/ChatFirestore+SendMessage.swift
+++ b/ChatNetworkingFirestore/Implementations/Firestore/ChatFirestore+SendMessage.swift
@@ -59,7 +59,7 @@ public extension ChatFirestore {
     private func prepareMessageData(message: MessageSpecificationFirestore, completion: @escaping (Result<[String: Any], ChatError>) -> Void) {
         let json = message.json
         
-        uploadMedia(for: json) { [weak self] result in
+        uploadMedia(for: json, path: message.uploadPath) { [weak self] result in
             guard let self = self, case let .success(json) = result else {
                 if case let .failure(error) = result {
                     completion(.failure(error))
@@ -75,7 +75,7 @@ public extension ChatFirestore {
         }
     }
     
-    private func uploadMedia(for json: ChatJSON, completion: @escaping (Result<ChatJSON, ChatError>) -> Void) {
+    private func uploadMedia(for json: ChatJSON, path: String? = nil, completion: @escaping (Result<ChatJSON, ChatError>) -> Void) {
         var normalizedJSON: ChatJSON = [:]
         var resultError: ChatError?
         
@@ -86,7 +86,7 @@ public extension ChatFirestore {
             case let value as MediaContent:
                 dispatchGroup.enter()
                 
-                mediaUploader.upload(content: value, on: self.networkingQueue) { result in
+                mediaUploader.upload(content: value, path: path, on: self.networkingQueue) { result in
                     switch result {
                     case .success(let url):
                         normalizedJSON[key] = url.absoluteString
@@ -99,7 +99,7 @@ public extension ChatFirestore {
             case let value as ChatJSON:
                 dispatchGroup.enter()
                 
-                uploadMedia(for: value) { result in
+                uploadMedia(for: value, path: path) { result in
                     switch result {
                     case .success(let json):
                         normalizedJSON[key] = json

--- a/ChatNetworkingFirestore/Implementations/Firestore/ChatFirestoreMediaUploader.swift
+++ b/ChatNetworkingFirestore/Implementations/Firestore/ChatFirestoreMediaUploader.swift
@@ -24,9 +24,9 @@ public class ChatFirestoreMediaUploader: MediaUploading {
     
     public init() {}
     
-    public func upload(content: MediaContent, on queue: DispatchQueue, completion: @escaping (Result<URL, ChatError>) -> Void) {
+    public func upload(content: MediaContent, path: String? = nil, on queue: DispatchQueue, completion: @escaping (Result<URL, ChatError>) -> Void) {
         content.dataForUpload { [weak self] data in
-            self?.upload(data: data, completion: { result in
+            self?.upload(data: data, path: path, completion: { result in
                 queue.async {
                     completion(result)
                 }
@@ -34,8 +34,9 @@ public class ChatFirestoreMediaUploader: MediaUploading {
         }
     }
     
-    private func upload(data: Data, completion: @escaping (Result<URL, ChatError>) -> Void) {
-        let ref = storage.reference().child(UUID().uuidString)
+    private func upload(data: Data, path: String? = nil, completion: @escaping (Result<URL, ChatError>) -> Void) {
+        let path = path ?? UUID().uuidString
+        let ref = storage.reference().child(path)
         
         ref.putData(data, metadata: nil) { (_, error) in
             if let error = error {

--- a/ChatNetworkingFirestore/Implementations/Firestore/Protocols/ChatFirestoreModeling.swift
+++ b/ChatNetworkingFirestore/Implementations/Firestore/Protocols/ChatFirestoreModeling.swift
@@ -16,7 +16,7 @@ public protocol ChatFirestoreModeling: ChatNetworkModeling where
     // Additional requirements for the message model
     NetworkMessage: Decodable,
     // Additional requirements for the message specification model
-    NetworkMessageSpecification: JSONConvertible,
+    NetworkMessageSpecification: JSONConvertible & UploadPathSpecifying,
     // Additional requirements for the user model
     NetworkUser: Decodable,
     // Additional requirements for the seen item


### PR DESCRIPTION
Added `UploadPathSpecifying` protocol and sample usage in the `MessageContent` (providing `conversationId` and `userId` to the enum case to be able to construct a desired upload path).