### PR TITLE
Use server timestamps instead of local

### DIFF
--- a/ChatNetworkingFirestore/Implementations/Firestore/ChatFirestore+SendMessage.swift
+++ b/ChatNetworkingFirestore/Implementations/Firestore/ChatFirestore+SendMessage.swift
@@ -70,7 +70,7 @@ public extension ChatFirestore {
 
             var newJSON: [String: Any] = json
             newJSON[self.constants.messages.userIdAttributeName] = self.currentUserId
-            newJSON[self.constants.messages.sentAtAttributeName] = Timestamp()
+            newJSON[self.constants.messages.sentAtAttributeName] = FieldValue.serverTimestamp()
             completion(.success(newJSON))
         }
     }

--- a/ChatNetworkingFirestore/Implementations/Firestore/ChatFirestore+UpdateSeenMessage.swift
+++ b/ChatNetworkingFirestore/Implementations/Firestore/ChatFirestore+UpdateSeenMessage.swift
@@ -24,7 +24,7 @@ public extension ChatFirestore {
             self.database.runTransaction({ (transaction, _) -> Any? in
                 let newSeenData = [
                     self.constants.conversations.seenAttribute.messageIdAttributeName: message,
-                    self.constants.conversations.seenAttribute.timestampAttributeName: Timestamp()
+                    self.constants.conversations.seenAttribute.timestampAttributeName: FieldValue.serverTimestamp()
                 ].merging(data ?? [:], uniquingKeysWith: { _, new in new })
 
                 transaction.setData([


### PR DESCRIPTION
If the user changes the date/time on their phone and sends a message the message list gets mixed up. That's why we should user server generated timestamps 👍 