### PR TITLE
Fix race condition

### DIFF
--- a/ChatCore/Utils/TaskManager.swift
+++ b/ChatCore/Utils/TaskManager.swift
@@ -11,16 +11,21 @@ import BackgroundTasks
 
 // MARK: Helper class to automatically manage closures by applying various attributes
 final class TaskManager {
+    /**
+     Because dictionary isn't thread-safe and the accessing (reading AND writing) the tasks storage can happen simultaneously within the core queue,
+     we have to prevent possible crashes by using dedicated queue to protect the storage and make sure only one thread access it at the time.
+     */
     class TaskCache {
+        // swiftlint:disable:next nesting
         typealias Closure = IdentifiableClosure<TaskCompletionResultHandler, Void>
         
-        private var storage: [Closure: Set<TaskAttribute>] = [:]
+        private lazy var storage: [Closure: Set<TaskAttribute>] = [:]
         private let queue = DispatchQueue(label: "com.strv.chatcore.taskcache.queue")
         
-        public subscript(key: Closure) -> Set<TaskAttribute> {
+        subscript(key: Closure) -> Set<TaskAttribute> {
             get {
-                return queue.sync {
-                    return storage[key] ?? []
+                queue.sync {
+                    storage[key] ?? []
                 }
             }
             set {
@@ -30,21 +35,21 @@ final class TaskManager {
             }
         }
         
-        public var isEmpty: Bool {
-            return queue.sync {
-                return storage.isEmpty
+        var isEmpty: Bool {
+            queue.sync {
+                storage.isEmpty
             }
         }
         
-        public var allTasks: [Closure: Set<TaskAttribute>] {
-            return queue.sync {
-                return storage
+        var allTasks: [Closure: Set<TaskAttribute>] {
+            queue.sync {
+                storage
             }
         }
         
-        public func removeAll() {
-            return queue.sync {
-                return storage.removeAll()
+        func removeAll() {
+            queue.sync {
+                storage.removeAll()
             }
         }
     }

--- a/ChatCore/Utils/TaskManager.swift
+++ b/ChatCore/Utils/TaskManager.swift
@@ -19,7 +19,7 @@ final class TaskManager {
         // swiftlint:disable:next nesting
         typealias Closure = IdentifiableClosure<TaskCompletionResultHandler, Void>
         
-        private lazy var storage: [Closure: Set<TaskAttribute>] = [:]
+        private var storage: [Closure: Set<TaskAttribute>] = [:]
         private let queue = DispatchQueue(label: "com.strv.chatcore.taskcache.queue")
         
         subscript(key: Closure) -> Set<TaskAttribute> {
@@ -98,7 +98,7 @@ final class TaskManager {
     typealias TaskCompletionResultHandler = (TaskCompletionResult) -> TaskCompletionState
 
     // Closure storage for calls before initialization
-    private let taskCache = TaskCache()
+    private lazy var taskCache = TaskCache()
     // tasks hooked to background task
     private var backgroundCalls = [IdentifiableClosure<TaskCompletionResultHandler, Void>]()
     private var backgroundTask: UIBackgroundTaskIdentifier = .invalid

--- a/ChatCore/Utils/TaskManager.swift
+++ b/ChatCore/Utils/TaskManager.swift
@@ -12,10 +12,12 @@ import BackgroundTasks
 // MARK: Helper class to automatically manage closures by applying various attributes
 final class TaskManager {
     class TaskCache {
-        private var storage: [IdentifiableClosure<TaskCompletionResultHandler, Void>: Set<TaskAttribute>] = [:]
+        typealias Closure = IdentifiableClosure<TaskCompletionResultHandler, Void>
+        
+        private var storage: [Closure: Set<TaskAttribute>] = [:]
         private let queue = DispatchQueue(label: "com.strv.chatcore.taskcache.queue")
         
-        public subscript(key: IdentifiableClosure<TaskCompletionResultHandler, Void>) -> Set<TaskAttribute> {
+        public subscript(key: Closure) -> Set<TaskAttribute> {
             get {
                 return queue.sync {
                     return storage[key] ?? []
@@ -34,7 +36,7 @@ final class TaskManager {
             }
         }
         
-        public var allTasks: [IdentifiableClosure<TaskCompletionResultHandler, Void>: Set<TaskAttribute>] {
+        public var allTasks: [Closure: Set<TaskAttribute>] {
             return queue.sync {
                 return storage
             }


### PR DESCRIPTION
Try to prevent race condition when writing and reading tasks cache by using a dedicated sync queue.

Issue: https://github.com/strvcom/ios-chat-component/issues/90

Following the approach shown in https://developer.apple.com/videos/play/wwdc2018/414/ (49:35)